### PR TITLE
[containers] check containers are running before test

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ Or use the `transfer` helper for simple account transfers.
 ```
 
 ## Troubleshooting
-There's a known issue where. Executing with `bun` to an `https` url API will fail. Since http/2 is not fully developed in `bun`. NodeJS (with npm, yarn, pnpm) does not appear to produce this error. Deno is untested.
+There's a known issue when executing using `bun`. Calling a fullnode with an `https` url API will fail. Since http/2 is not fully developed in `bun` as of 1.2.2.
+
+NodeJS (with npm, yarn, pnpm) does not appear to produce this error. Deno is untested.
 
 ## Flavors
 Look in the `./examples` folder for commonjs, Node, and typescript imports of the module.

--- a/tests/support/compose.ts
+++ b/tests/support/compose.ts
@@ -1,6 +1,7 @@
 import {
   downAll,
   logs,
+  ps,
   upAll,
   type IDockerComposeOptions,
 } from "docker-compose";
@@ -14,25 +15,59 @@ const options: IDockerComposeOptions = {
   // log: true,
 };
 
-export async function testnetUp(): Promise<void> {
+export async function testnetUp(): Promise<boolean> {
   await upAll(options);
 
-  const targetString = "QCReady"; // Replace with the actual string you expect
-
+  const targetString = "QCReady";
+  console.log("waiting for logs");
   while (true) {
     const logOutput = await logs("alice", options);
-    //       const targetString = `"event":"NewRound","reason":"QCReady"`; // Replace with the actual string you expect
 
     if (logOutput.out.includes(targetString)) {
       console.log("testnet started, proceeding...");
       break; // Exit the loop when the message is found
     }
 
+    if (logOutput.out.includes("exited with code")) {
+      console.log(`last logs: ${logOutput.out}`);
+      throw new Error("containers exited with non zero code!");
+    }
+
+    const runs = await isComposeRunning(composeFilePath);
+    if (!runs) {
+      console.log(`last logs: ${logOutput.out}`);
+
+      throw new Error("containers are not running!");
+    }
     // check logs every second
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
+  return true;
 }
 
 export async function testnetDown() {
   await downAll(options);
+}
+
+async function isComposeRunning(path: string): Promise<boolean> {
+  try {
+    const result = await ps({
+      cwd: path,
+      commandOptions: [["--format", "json"]],
+    });
+    if (!result || result.data.services.length == 0) {
+      console.error("[ERROR] no containers running");
+      return false;
+    }
+    for (const service of result.data.services) {
+      if (service.state != "running") {
+        console.error(`[ERROR] service ${service.name} is not running`);
+        return false;
+      }
+    }
+  } catch {
+    console.error("[ERROR] could not run docker-compose ps");
+    return false;
+  }
+  return true;
 }

--- a/tests/support/container/entrypoint.sh
+++ b/tests/support/container/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Install dependencies silently
+apt update
 apt install -y curl
 
 # Display version


### PR DESCRIPTION
Test runner was hanging when the docker compose command aborted. Make it explicitly throw if containers are note running.
Also patches compose entrypoint.sh  to include step for `apt update`.