### PR TITLE
[testnet] better handling of searching for docker executable

### DIFF
--- a/examples/local_testnet.ts
+++ b/examples/local_testnet.ts
@@ -1,0 +1,57 @@
+import { testnetUp, testnetDown, DOCKER_URL, LibraClient, Network } from 'open-libra-sdk';
+
+// Function to handle cleanup when the script is interrupted
+function setupShutdownHandler() {
+  // Handle SIGINT (Ctrl+C) to properly shut down the testnet
+  process.on('SIGINT', async () => {
+    console.log('\nShutting down testnet...');
+    await testnetDown();
+    console.log('Testnet shut down successfully');
+    process.exit(0);
+  });
+}
+
+async function main() {
+  try {
+
+    // Setup the shutdown handler
+    setupShutdownHandler();
+
+    console.log('Starting local testnet...');
+    // Start the testnet and wait for it to be ready
+    const started = await testnetUp();
+
+    if (started) {
+      console.log('✅ Local testnet is up and running!');
+      console.log(`API endpoint: ${DOCKER_URL}`);
+
+      // Create a client connected to the local testnet
+      const client = new LibraClient(Network.TESTNET, DOCKER_URL);
+
+      // Verify the connection by getting the ledger info
+      const ledgerInfo = await client.getLedgerInfo();
+      console.log('\nTestnet status:');
+      console.log(`Chain ID: ${ledgerInfo.chain_id}`);
+      console.log(`Blockchain version: ${ledgerInfo.block_height}`);
+      console.log(`Ledger timestamp: ${new Date(ledgerInfo.ledger_timestamp / 1000).toISOString()}`);
+
+      console.log('\nTestnet is ready for testing. Press Ctrl+C to shut down.');
+
+      // Keep the process running until interrupted
+      console.log('\nThe testnet will remain running until you press Ctrl+C...');
+    } else {
+      console.error('❌ Failed to start local testnet');
+    }
+    await testnetDown();
+  } catch (error) {
+    console.error('Error occurred:', error);
+    await testnetDown();
+    process.exit(1);
+  }
+}
+
+// Run the main function
+main().catch(error => {
+  console.error('Unhandled error in main:', error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-libra-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A minimalist Typescript library for interacting with the Open Libra blockchain.",
   "homepage": "https://github.com/0LNetworkCommunity/open-libra-sdk#readme",
   "bugs": {

--- a/src/local_testnet/compose.ts
+++ b/src/local_testnet/compose.ts
@@ -6,56 +6,127 @@ import {
   type IDockerComposeOptions,
 } from "docker-compose";
 import path from "path";
+import { execSync } from "child_process";
 
 const composeFilePath = path.resolve(__dirname, "container");
 
-const options: IDockerComposeOptions = {
-  cwd: composeFilePath,
-  // NOTE: enable to debug all docker compose output and container logs
-  // log: true,
-};
+// Check if docker is available in PATH or at the specified path
+function checkDockerAvailability(customDockerPath?: string): string | null {
+  try {
+    if (customDockerPath) {
+      // Test if the provided custom path works
+      execSync(`"${customDockerPath}" --version`, { stdio: "ignore" });
+      return customDockerPath;
+    } else {
+      // Try to find docker in PATH
+      const dockerPath = execSync("which docker", {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "ignore"],
+      }).trim();
+      return dockerPath || null;
+    }
+  } catch (error) {
+    // If the command fails, it means docker is not available
+    console.error(
+      "Docker executable not found in PATH or at the specified path.",
+    );
+    console.error(
+      "Please ensure Docker is installed and in your PATH, or provide the full path to the Docker executable.",
+    );
+    console.error(
+      "Error details:",
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+}
 
 export const LOCAL_TESTNET_API: string = "http://localhost:8380/v1";
 
-export async function testnetUp(): Promise<boolean> {
-  await upAll(options);
+export async function testnetUp(dockerPath?: string): Promise<boolean> {
+  const foundDockerPath = checkDockerAvailability(dockerPath);
 
-  const targetString = "QCReady";
-  console.log("waiting for logs");
-  while (true) {
-    const logOutput = await logs("alice", options);
-
-    if (logOutput.out.includes(targetString)) {
-      console.log("testnet started, proceeding...");
-      break; // Exit the loop when the message is found
-    }
-
-    if (logOutput.out.includes("exited with code")) {
-      console.log(`last logs: ${logOutput.out}`);
-      throw new Error("containers exited with non zero code!");
-    }
-
-    const runs = await isComposeRunning(composeFilePath);
-    if (!runs) {
-      console.log(`last logs: ${logOutput.out}`);
-
-      throw new Error("containers are not running!");
-    }
-    // check logs every second
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  if (!foundDockerPath) {
+    throw new Error(
+      "Docker executable not found. Please ensure Docker is installed and in your PATH, " +
+        "or provide the full path to the Docker executable as a parameter.",
+    );
   }
-  return true;
+
+  const options: IDockerComposeOptions = {
+    cwd: composeFilePath,
+    executable: {
+      executablePath: foundDockerPath,
+    },
+    // NOTE: enable to debug all docker compose output and container logs
+    // log: true,
+  };
+
+  try {
+    await upAll(options);
+
+    const targetString = "QCReady";
+    console.log("waiting for logs");
+    while (true) {
+      const logOutput = await logs("alice", options);
+
+      if (logOutput.out.includes(targetString)) {
+        console.log("testnet started, proceeding...");
+        break; // Exit the loop when the message is found
+      }
+
+      if (logOutput.out.includes("exited with code")) {
+        console.log(`last logs: ${logOutput.out}`);
+        throw new Error("containers exited with non zero code!");
+      }
+
+      const runs = await isComposeRunning(composeFilePath, foundDockerPath);
+      if (!runs) {
+        console.log(`last logs: ${logOutput.out}`);
+
+        throw new Error("containers are not running!");
+      }
+      // check logs every second
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+    return true;
+  } catch (error) {
+    console.error("Failed to start testnet:", error);
+    throw error;
+  }
 }
 
-export async function testnetDown() {
+export async function testnetDown(dockerPath?: string) {
+  const foundDockerPath = checkDockerAvailability(dockerPath);
+
+  if (!foundDockerPath) {
+    console.warn(
+      "Docker executable not found. Unable to shut down testnet containers.",
+    );
+    return;
+  }
+
+  const options: IDockerComposeOptions = {
+    cwd: composeFilePath,
+    executable: {
+      executablePath: foundDockerPath,
+    },
+  };
+
   await downAll(options);
 }
 
-async function isComposeRunning(path: string): Promise<boolean> {
+async function isComposeRunning(
+  composePath: string,
+  dockerPath: string,
+): Promise<boolean> {
   try {
     const result = await ps({
-      cwd: path,
+      cwd: composePath,
       commandOptions: [["--format", "json"]],
+      executable: {
+        executablePath: dockerPath,
+      },
     });
     if (!result || result.data.services.length == 0) {
       console.error("[ERROR] no containers running");
@@ -67,8 +138,8 @@ async function isComposeRunning(path: string): Promise<boolean> {
         return false;
       }
     }
-  } catch {
-    console.error("[ERROR] could not run docker-compose ps");
+  } catch (error) {
+    console.error("[ERROR] could not run docker-compose ps:", error);
     return false;
   }
   return true;


### PR DESCRIPTION
Testnet startup for apps consuming the sdk was sometimes flaky. The process.env wouldn't alway inherit the path, depending how the dev set up calling the function.

- [x] search and confirm docker can be found in path
- [x] allow dev to set a path override