### PR TITLE
[client] cors without credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-libra-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A minimalist Typescript library for interacting with the Open Libra blockchain.",
   "homepage": "https://github.com/0LNetworkCommunity/open-libra-sdk#readme",
   "bugs": {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -28,8 +28,8 @@ export class LibraClient extends Aptos {
       network: network ?? Network.MAINNET,
       fullnode: fullnode ?? MAINNET_URL,
       clientConfig: {
-        WITH_CREDENTIALS: false // will cause CORS sadness
-      }
+        WITH_CREDENTIALS: false, // will cause CORS sadness
+      },
     });
 
     super(config);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -27,6 +27,9 @@ export class LibraClient extends Aptos {
     const config = new AptosConfig({
       network: network ?? Network.MAINNET,
       fullnode: fullnode ?? MAINNET_URL,
+      clientConfig: {
+        WITH_CREDENTIALS: false // will cause CORS sadness
+      }
     });
 
     super(config);


### PR DESCRIPTION
Poem OpenAPI as implemented in Diem vendor has interesting choices on authorizing CORS with credentials. We don't use credentials in OL for API.