### PR TITLE
[exports] update react native distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "react-native": "./dist/esm/index.mjs",
+      "react-native": "./dist/browser/index.js",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs",
       "default": "./dist/esm/index.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-libra-sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A minimalist Typescript library for interacting with the Open Libra blockchain.",
   "homepage": "https://github.com/0LNetworkCommunity/open-libra-sdk#readme",
   "bugs": {


### PR DESCRIPTION
React native will default to use the same exported modules as browser. This includes client, wallet, and keygen.